### PR TITLE
Initial packaging: version 2.5.6

### DIFF
--- a/SOURCES/atlantic-module-alt-2.5.6.tar.gz
+++ b/SOURCES/atlantic-module-alt-2.5.6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54d4c9dcf81243f4fd339e17a569863182ff3449bc7e294c3ce599a6ea6fe6e2
+size 228929

--- a/SPECS/atlantic-module.spec
+++ b/SPECS/atlantic-module.spec
@@ -1,0 +1,55 @@
+%define module_dir extra
+
+Summary: Driver for Atlantic aQuantia AQtion aQuantia Multi-Gigabit PCI Express Family of Ethernet Adapters
+Name: atlantic-module-alt
+Version: 2.5.6
+Release: 1%{?dist}
+License: GPL
+
+#Source taken from https://www.marvel.com/content/dam/marvell/en/drivers/marvel_linux_2.5.6.zip
+Source: %{name}-%{version}.tar.gz
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+%description
+Driver for Atlantic aQuantia AQtion aQuantia Multi-Gigabit PCI Express Family of Ethernet Adapters
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) modules
+
+%install
+%{__make} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+
+# remove extra files modules_install copies in
+rm -f %{buildroot}/lib/modules/%{kernel_version}/modules.*
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+
+%changelog
+* Sat Aug 16 2023 Andrew Lindh <andrew@netplex.net> - 2.5.6-1
+- Update vendor version of driver 2.5.6
+
+* Fri Feb 17 2023 Andrew Lindh <andrew@netplex.net> - 2.5.5-1
+- Release test version of driver 2.5.5


### PR DESCRIPTION
Driver version 2.5.6 for Atlantic aQuantia AQtion aQuantia Multi-Gigabit PCI Express Family of Ethernet Adapters

PR created on behalf of @andrew64k, based on https://github.com/andrew64k/atlantic-module-alt2